### PR TITLE
Add line_item hash into hash_item method

### DIFF
--- a/core/app/models/spree/stock/prioritizer.rb
+++ b/core/app/models/spree/stock/prioritizer.rb
@@ -47,10 +47,12 @@ module Spree
       def hash_item(item)
         shipment = item.inventory_unit.shipment
         variant  = item.inventory_unit.variant
+        line_item = item.inventory_unit.line_item
+        base_hash = variant.hash ^ line_item.hash
         if shipment.present?
-          variant.hash ^ shipment.hash
+          base_hash ^ shipment.hash
         else
-          variant.hash
+          base_hash
         end
       end
     end


### PR DESCRIPTION
The @adjuster[hash_item item] would cause the adjuster to discard additional package content items that reference the same variant_id as a content item that has already been iterated over, but which should be processed separately from each other (for example when using line_item_comparison_hooks).