### PR TITLE
Index inventory_units by line_item_it instead of variant_id

### DIFF
--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -20,9 +20,9 @@ module Spree
       def default_package
         package = Package.new(stock_location)
 
-        # Group by variant_id as grouping by variant fires cached query.
-        inventory_units.index_by(&:variant_id).each do |variant_id, inventory_unit|
-          variant = Spree::Variant.find(variant_id)
+        inventory_units.index_by(&:line_item_id).each do |line_item_id, inventory_unit|
+          line_item = Spree::LineItem.find(line_item_id)
+          variant = line_item.variant
           unit = inventory_unit.dup # Can be used by others, do not use directly
           if variant.should_track_inventory?
             next unless stock_location.stocks? variant


### PR DESCRIPTION
When an order has two line_items that have the same variant_id (for example when using line_item_comparison_hooks), they were effectively getting merged and added into a package as one inventory_unit. Grouping by line_item_id fixes that.